### PR TITLE
Exit early when no layer is active to prevent stacktraces flooding the Macro output

### DIFF
--- a/ShowDistanceAndAngleOfNodes.glyphsReporter/Contents/Resources/plugin.py
+++ b/ShowDistanceAndAngleOfNodes.glyphsReporter/Contents/Resources/plugin.py
@@ -138,6 +138,8 @@ class ShowDistanceAndAngle ( ReporterPlugin ):
 			print traceback.format_exc()
 
 	def drawNodeDistanceText( self, layer ):
+		if layer is None:
+			return
 		try:
 			try:
 				selection = layer.selection


### PR DESCRIPTION
Hey,
a small tweak to an otherwise great plugin I have in my local install - maybe you'd like to merge :) 

When no layer is active the listener will run and since `layer` is not defined will output tracebacks to the Macro window console, a lot. This small addition just exists early, and silently, when this is the case.